### PR TITLE
minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+*.vsidx
+*.lock

--- a/Movies Icons/Form1.Designer.vb
+++ b/Movies Icons/Form1.Designer.vb
@@ -172,7 +172,7 @@ Partial Class Form1
         Me.TextBox2.Name = "TextBox2"
         Me.TextBox2.Size = New System.Drawing.Size(100, 20)
         Me.TextBox2.TabIndex = 13
-        Me.TextBox2.Text = "poster.*"
+        Me.TextBox2.Text = "*-poster.*"
         '
         'Label4
         '
@@ -239,8 +239,6 @@ Partial Class Form1
         'CheckBox3
         '
         Me.CheckBox3.AutoSize = True
-        Me.CheckBox3.Checked = True
-        Me.CheckBox3.CheckState = System.Windows.Forms.CheckState.Checked
         Me.CheckBox3.Location = New System.Drawing.Point(313, 19)
         Me.CheckBox3.Name = "CheckBox3"
         Me.CheckBox3.Size = New System.Drawing.Size(192, 17)
@@ -251,6 +249,8 @@ Partial Class Form1
         'CheckBox2
         '
         Me.CheckBox2.AutoSize = True
+        Me.CheckBox2.Checked = True
+        Me.CheckBox2.CheckState = System.Windows.Forms.CheckState.Checked
         Me.CheckBox2.Location = New System.Drawing.Point(6, 42)
         Me.CheckBox2.Name = "CheckBox2"
         Me.CheckBox2.Size = New System.Drawing.Size(114, 17)

--- a/Movies Icons/Form1.vb
+++ b/Movies Icons/Form1.vb
@@ -355,7 +355,13 @@ Public Class Form1
                     image.Dispose()
                 End Using
 
-                bmp.Save(Path.GetDirectoryName(filename) + "\" + Path.GetFileNameWithoutExtension(filename) + "-MIC.png", Imaging.ImageFormat.Png)
+                'Try saving edited image as folder.jpg to expand compatibility to some network folders and NAS drives
+                Try
+                    'wrapped in try/catch block as sometimes saving the file to jpg can throw an exception
+                    bmp.Save(Path.GetDirectoryName(filename) + "\" + "folder.jpg", Imaging.ImageFormat.Jpeg)
+                Catch ex As Exception
+                    bmp.Save(Path.GetDirectoryName(filename) + "\" + Path.GetFileNameWithoutExtension(filename) + "-MIC.png", Imaging.ImageFormat.Png)
+                End Try
                 bmp.Dispose()
                 g.Dispose()
 
@@ -441,6 +447,7 @@ Public Class Form1
                 If Path.GetFileName(hFile) = "clearart.png" _
                     Or Path.GetFileName(hFile) = "disc.png" _
                     Or Path.GetFileName(hFile) = "logo.png" _
+                    Or Path.GetFileName(hFile) = "folder.jpg" _
                     Or Path.GetFileName(hFile) = "desktop.ini" _
                     Or Path.GetFileName(hFile).Contains("-banner.") _
                     Or Path.GetFileName(hFile).Contains("thumb.") _
@@ -454,9 +461,17 @@ Public Class Form1
                     Or Path.GetFileName(hFile).Contains("-MIC.png") _
                     Or Path.GetExtension(hFile) = (".nfo") _
                     Or Path.GetExtension(hFile) = (".ico") _
+                    Or Path.GetExtension(hFile) = (".srt") _
+                    Or Path.GetExtension(hFile) = (".ssa") _
                     Then
 
                     File.SetAttributes(hFile, FileAttributes.Hidden)
+                End If
+                'delete legacy file as it is replaced by folder.jpg
+                If Path.GetFileName(hFile).Contains("-MIC.png") _
+                    Then
+
+                    File.Delete(hFile)
                 End If
 
             Next


### PR DESCRIPTION
- updating default filter
- updating the default to hide metadata files fixes #4 
- disabling the rating by default until issue is fixed, temporary workaround for #5 
- saving design as folder.jpg to increase compatibility with different filesystems, can help with #7 